### PR TITLE
Adding some fixes for the auto-assign feature.

### DIFF
--- a/internal/gitstream/assign.go
+++ b/internal/gitstream/assign.go
@@ -82,6 +82,11 @@ func (a *Assign) assignIssues(ctx context.Context) error {
 	for _, issue := range issues {
 
 		logger := a.Logger.WithValues("url", *issue.HTMLURL)
+
+		if len(issue.Assignees) > 0 {
+			continue
+		}
+
 		logger.Info("Processing issue")
 
 		shas, err := a.Finder.FindSHAs(*issue.Body)

--- a/internal/gitstream/assign.go
+++ b/internal/gitstream/assign.go
@@ -108,12 +108,17 @@ func (a *Assign) assignIssues(ctx context.Context) error {
 
 			logger.Info("Assigning issue")
 
+			var userLogin string
 			user, err := a.UserHelper.GetUser(ctx, upstreamCommit)
 			if err != nil {
-				return fmt.Errorf("could not get the upstream commit author for downstream issue %d: %v", *issue.Number, err)
+				logger.Info("WARNING: could not get the upstream commit author for downstream issue, picking a random assignee",
+					"issue", *issue.Number)
+				userLogin = "notanowner"
+			} else {
+				userLogin = *user.Login
 			}
 
-			assignee, err := owners.getAssignee(ctx, a.GC, *user.Login)
+			assignee, err := owners.getAssignee(ctx, a.GC, userLogin)
 			if err != nil {
 				return fmt.Errorf("could not get select a suitable assignee: %v", err)
 			}

--- a/internal/gitstream/assign_test.go
+++ b/internal/gitstream/assign_test.go
@@ -461,8 +461,9 @@ reviewers:
 			},
 		}
 
-		hash := plumbing.NewHash("1167d3564b3f54ee1fca996572021f0206bb3ba9")
-		hashes := []plumbing.Hash{hash}
+		ref, err := repo.Head()
+		assert.NoError(t, err)
+		hashes := []plumbing.Hash{ref.Hash()}
 
 		gomock.InOrder(
 			mockIssueHelper.EXPECT().ListAllOpen(ctx, true).Return(issues, nil),
@@ -470,7 +471,7 @@ reviewers:
 			mockUserHelper.EXPECT().GetUser(ctx, gomock.Any()).Return(nil, errors.New("some error")),
 		)
 
-		err := a.assignIssues(ctx)
+		err = a.assignIssues(ctx)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "could not get the upstream commit author for downstream issue")
 	})
@@ -545,8 +546,9 @@ reviewers:
 			},
 		}
 
-		hash := plumbing.NewHash("1167d3564b3f54ee1fca996572021f0206bb3ba9")
-		hashes := []plumbing.Hash{hash}
+		ref, err := repo.Head()
+		assert.NoError(t, err)
+		hashes := []plumbing.Hash{ref.Hash()}
 
 		user := &github.User{
 			Login: &userLogin,
@@ -559,7 +561,7 @@ reviewers:
 			mockIssueHelper.EXPECT().Assign(ctx, issues[0], userLogin).Return(errors.New("error")),
 		)
 
-		err := a.assignIssues(ctx)
+		err = a.assignIssues(ctx)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "could not assign issue")
 	})
@@ -634,8 +636,9 @@ reviewers:
 			},
 		}
 
-		hash := plumbing.NewHash("1167d3564b3f54ee1fca996572021f0206bb3ba9")
-		hashes := []plumbing.Hash{hash}
+		ref, err := repo.Head()
+		assert.NoError(t, err)
+		hashes := []plumbing.Hash{ref.Hash()}
 
 		user := &github.User{
 			Login: &userLogin,
@@ -648,7 +651,7 @@ reviewers:
 			mockIssueHelper.EXPECT().Assign(ctx, issues[0], userLogin).Return(nil),
 		)
 
-		err := a.assignIssues(ctx)
+		err = a.assignIssues(ctx)
 		assert.NoError(t, err)
 	})
 }

--- a/internal/gitstream/assign_test.go
+++ b/internal/gitstream/assign_test.go
@@ -551,6 +551,7 @@ reviewers:
 			mockIssueHelper.EXPECT().ListAllOpen(ctx, true).Return(issues, nil),
 			mockFinder.EXPECT().FindSHAs(gomock.Any()).Return(hashes, nil),
 			mockUserHelper.EXPECT().GetUser(ctx, gomock.Any()).Return(nil, errors.New("some error")),
+			mockIssueHelper.EXPECT().Assign(ctx, issues[0], gomock.Any()).Return(nil),
 		)
 
 		err = a.assignIssues(ctx)

--- a/internal/gitstream/assign_test.go
+++ b/internal/gitstream/assign_test.go
@@ -313,6 +313,88 @@ reviewers:
 		assert.Contains(t, err.Error(), "could not list open issues")
 	})
 
+	t.Run("do nothing if the issue is already assigned", func(t *testing.T) {
+
+		var (
+			ctx = context.Background()
+		)
+
+		expectedContent := &github.RepositoryContent{
+			Encoding: &encoding,
+			Content:  &encodedContent,
+		}
+
+		c := mock.NewMockedHTTPClient(
+			mock.WithRequestMatchHandler(
+				mock.GetReposContentsByOwnerByRepoByPath,
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					assert.Contains(t, r.URL.Path, "OWNERS")
+					assert.NoError(
+						t,
+						json.NewEncoder(w).Encode(expectedContent),
+					)
+				}),
+			),
+		)
+
+		gc := github.NewClient(c)
+		ctrl := gomock.NewController(t)
+
+		mockFinder := markup.NewMockFinder(ctrl)
+		mockGitHelper := gitutils.NewMockHelper(ctrl)
+		mockIssueHelper := gh.NewMockIssueHelper(ctrl)
+		mockUserHelper := gh.NewMockUserHelper(ctrl)
+
+		repo, _ := test.CloneCurrentRepoWithFS(t)
+		ghRepoName := &gh.RepoName{
+			Owner: repoOwner,
+			Repo:  repoName,
+		}
+
+		upstreamConfig := config.Upstream{
+			Ref: upstreamMainBranch,
+			URL: upstreamURL,
+		}
+
+		a := Assign{
+			GC:             gc,
+			DryRun:         false,
+			Finder:         mockFinder,
+			GitHelper:      mockGitHelper,
+			Logger:         logr.Discard(),
+			IssueHelper:    mockIssueHelper,
+			UserHelper:     mockUserHelper,
+			Repo:           repo,
+			RepoName:       ghRepoName,
+			UpstreamConfig: upstreamConfig,
+		}
+
+		var (
+			issueNumber = 123
+			issueURL    = "some url"
+			body        = "some body"
+			login       = "user1"
+		)
+		issues := []*github.Issue{
+			{
+				Number:  &issueNumber,
+				HTMLURL: &issueURL,
+				Body:    &body,
+				Assignees: []*github.User{
+					{
+						Login: &login,
+					},
+				},
+			},
+		}
+		gomock.InOrder(
+			mockIssueHelper.EXPECT().ListAllOpen(ctx, true).Return(issues, nil),
+		)
+
+		err := a.assignIssues(ctx)
+		assert.NoError(t, err)
+	})
+
 	t.Run("failed to find SHAs", func(t *testing.T) {
 
 		var (


### PR DESCRIPTION
This PR contains of multiple commits and consist of:
* Skipping assigning already-assigned issues
* Pick a random owner in case we failed to get the Github user.