### PR TITLE
Using the HEAD ref as sha instead of hardcoding it in the tests.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          # Unit tests use the repo's git history
-          fetch-depth: 0
-          ref: main
 
       - uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
Signed-off-by: Yoni Bettan <yonibettan@gmail.com>