### PR TITLE
Skipping issues that are already assigned.

### DIFF
--- a/internal/gitstream/assign.go
+++ b/internal/gitstream/assign.go
@@ -82,6 +82,11 @@ func (a *Assign) assignIssues(ctx context.Context) error {
 	for _, issue := range issues {
 
 		logger := a.Logger.WithValues("url", *issue.HTMLURL)
+
+		if len(issue.Assignees) > 0 {
+			continue
+		}
+
 		logger.Info("Processing issue")
 
 		shas, err := a.Finder.FindSHAs(*issue.Body)


### PR DESCRIPTION
There is not need to re-assign assigned issues. Further more in case a random approver is chosen, we don't want to keep assigning random approver each time the command is triggered.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>