### PR TITLE
Pick a random approver in case we failed to get the user.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -53,6 +53,7 @@ require (
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
 	golang.org/x/crypto v0.3.0 // indirect
+	golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb // indirect
 	golang.org/x/net v0.6.0 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/term v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,10 @@ golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.0.0-20220826181053-bd7e27e6170d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.3.0 h1:a06MkbcxBrEFc0w0QIZWXrH/9cCX6KJyWbBOIwAn+7A=
 golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
+golang.org/x/exp v0.0.0-20230212135524-a684f29349b6 h1:Ic9KukPQ7PegFzHckNiMTQXGgEszA7mY2Fn4ZMtnMbw=
+golang.org/x/exp v0.0.0-20230212135524-a684f29349b6/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
+golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb h1:PaBZQdo+iSDyHT053FjUCgZQ/9uqVwPOcl7KSWhKn6w=
+golang.org/x/exp v0.0.0-20230213192124-5e25df0256eb/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/internal/github/user.go
+++ b/internal/github/user.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-git/go-git/v5/plumbing/object"
@@ -27,15 +28,17 @@ func NewUserHelper(gc *github.Client, repoName *RepoName) UserHelper {
 	}
 }
 
+var ErrUnexpectedReply = errors.New("the users search result are incoclusive")
+
 func (uh *UserHelperImpl) GetUser(ctx context.Context, commit *object.Commit) (*github.User, error) {
 
 	email := commit.Author.Email
 	userSearchRes, _, err := uh.gc.Search.Users(ctx, email, nil)
 	if err != nil {
-		return nil, fmt.Errorf("could not get user from email %s: %v", email, err)
+		return nil, fmt.Errorf("failed to get user %s: %v", email, err)
 	}
 	if len(userSearchRes.Users) != 1 {
-		return nil, fmt.Errorf("there is more than 1 user associated with %s: %v", email, err)
+		return nil, ErrUnexpectedReply
 	}
 	return userSearchRes.Users[0], nil
 }

--- a/internal/gitstream/owners.go
+++ b/internal/gitstream/owners.go
@@ -1,10 +1,10 @@
 package gitstream
 
 import (
-	"context"
+	"fmt"
 	"math/rand"
 
-	"github.com/google/go-github/v47/github"
+	"golang.org/x/exp/slices"
 )
 
 type Owners struct {
@@ -13,15 +13,20 @@ type Owners struct {
 	Component string   `yaml:"component"`
 }
 
-func (o *Owners) getAssignee(ctx context.Context, gc *github.Client, userLogin string) (string, error) {
+func (o *Owners) contains(userLogin string) bool {
 
-	for _, approver := range o.Approvers {
-		if approver == userLogin {
-			return userLogin, nil
-		}
+	return slices.Contains(o.Approvers, userLogin)
+}
+
+func (o *Owners) getRandom() (string, error) {
+
+	numApprovers := len(o.Approvers)
+
+	// rand.Intn will panic if the operrand is <= 0
+	if numApprovers <= 0 {
+		return "", fmt.Errorf("There is no approvers in the %s file", ownersFile)
 	}
 
-	// User isn't in m/s OWNER file, select a random owner
 	rand := rand.Intn(len(o.Approvers))
 	return o.Approvers[rand], nil
 }


### PR DESCRIPTION
ATM, we are picking a random assignee in case the Github user isn't present in the `OWNERS` file. This commit is extending that logic to also pick a random approver case we couldn't find the user at all (regardless of if he is in the `OWNERS` file or not).

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>