### PR TITLE
Adding a list of ignored authors from the `sync` subcommand.

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,11 +11,12 @@ import (
 )
 
 type Downstream struct {
-	CreateDraftPRs bool   `yaml:"create_draft_prs"`
-	GitHubRepoName string `yaml:"github_repo_name"`
-	LocalRepoPath  string `yaml:"local_repo_path" default:"."`
-	MainBranch     string `yaml:"main_branch" default:"main"`
-	MaxOpenItems   int    `yaml:"max_open_items" default:"-1"`
+	CreateDraftPRs bool     `yaml:"create_draft_prs"`
+	GitHubRepoName string   `yaml:"github_repo_name"`
+	LocalRepoPath  string   `yaml:"local_repo_path" default:"."`
+	MainBranch     string   `yaml:"main_branch" default:"main"`
+	MaxOpenItems   int      `yaml:"max_open_items" default:"-1"`
+	IgnoreAuthors  []string `yaml:"ignore_authors"`
 }
 
 type Diff struct {

--- a/internal/gitstream/sync_test.go
+++ b/internal/gitstream/sync_test.go
@@ -21,127 +21,231 @@ import (
 )
 
 func TestSync_Run(t *testing.T) {
-	ctrl := gomock.NewController(t)
 
-	const (
-		createDraftPRs       = true
-		downstreamMainBranch = "main"
-		dryRun               = false
-		githubToken          = "github-token"
-		repoOwner            = "owner"
-		repoPath             = "/repo/path"
-		repoName             = "repo"
-		upstreamMainBranch   = "us-main"
-		upstreamURL          = "some-upstream-url"
-	)
+	t.Run("working as expected", func(t *testing.T) {
 
-	mockCP := gitutils.NewMockCherryPicker(ctrl)
-	mockIssueHelper := gh.NewMockIssueHelper(ctrl)
-	mockPRHelper := gh.NewMockPRHelper(ctrl)
-	mockDiffer := gitutils.NewMockDiffer(ctrl)
-	mockHelper := gitutils.NewMockHelper(ctrl)
+		ctrl := gomock.NewController(t)
 
-	ctx := context.Background()
-
-	repo := test.NewRepo(t)
-	sha, _ := test.AddEmptyCommit(t, repo, "test commit")
-
-	for _, name := range []string{upstreamMainBranch, downstreamMainBranch} {
-		ref := plumbing.NewHashReference(
-			plumbing.NewBranchReferenceName(name),
-			sha,
+		const (
+			createDraftPRs       = true
+			downstreamMainBranch = "main"
+			dryRun               = false
+			githubToken          = "github-token"
+			repoOwner            = "owner"
+			repoPath             = "/repo/path"
+			repoName             = "repo"
+			upstreamMainBranch   = "us-main"
+			upstreamURL          = "some-upstream-url"
 		)
 
-		require.NoError(
+		mockCP := gitutils.NewMockCherryPicker(ctrl)
+		mockIssueHelper := gh.NewMockIssueHelper(ctrl)
+		mockPRHelper := gh.NewMockPRHelper(ctrl)
+		mockDiffer := gitutils.NewMockDiffer(ctrl)
+		mockHelper := gitutils.NewMockHelper(ctrl)
+
+		ctx := context.Background()
+
+		repo := test.NewRepo(t)
+		sha, _ := test.AddEmptyCommit(t, repo, "test commit")
+
+		for _, name := range []string{upstreamMainBranch, downstreamMainBranch} {
+			ref := plumbing.NewHashReference(
+				plumbing.NewBranchReferenceName(name),
+				sha,
+			)
+
+			require.NoError(
+				t,
+				repo.Storer.SetReference(ref),
+			)
+		}
+
+		ghRepoName := gh.RepoName{
+			Owner: repoOwner,
+			Repo:  repoName,
+		}
+
+		since := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
+		logger := logr.Discard()
+
+		upstreamConfig := config.Upstream{
+			Ref: upstreamMainBranch,
+			URL: upstreamURL,
+		}
+
+		s := Sync{
+			CherryPicker: mockCP,
+			Differ:       mockDiffer,
+			DiffConfig: config.Diff{
+				CommitsSince: &since,
+			},
+			DryRun:      dryRun,
+			GitHelper:   mockHelper,
+			GitHubToken: githubToken,
+			IssueHelper: mockIssueHelper,
+			Repo:        repo,
+			RepoName:    &ghRepoName,
+			DownstreamConfig: config.Downstream{
+				CreateDraftPRs: createDraftPRs,
+				LocalRepoPath:  repoPath,
+				MainBranch:     downstreamMainBranch,
+				MaxOpenItems:   -1,
+			},
+			Logger:         logger,
+			PRHelper:       mockPRHelper,
+			UpstreamConfig: upstreamConfig,
+		}
+
+		const (
+			sha1    = "e3229f3c533ed51070beff092e5c7694a8ee81f0"
+			sha2    = "9c08d42326af62aa0f8cea021c4d37971606148f"
+			branch2 = "gs-" + sha2
+		)
+
+		commit1 := &object.Commit{
+			Hash: plumbing.NewHash(sha1),
+			Committer: object.Signature{
+				When: time.Date(2022, 5, 1, 0, 0, 0, 0, time.UTC),
+			},
+		}
+
+		commit2 := &object.Commit{
+			Hash: plumbing.NewHash(sha2),
+			Committer: object.Signature{
+				When: time.Date(2022, 4, 1, 0, 0, 0, 0, time.UTC),
+			},
+		}
+
+		randomError := errors.New("random error")
+
+		gomock.InOrder(
+			mockDiffer.
+				EXPECT().
+				GetMissingCommits(ctx, repo, &ghRepoName, &since, downstreamMainBranch, upstreamConfig).
+				Return([]*object.Commit{commit1, commit2}, nil),
+			mockIssueHelper.EXPECT().ListAllOpen(gomock.Any(), true),
+			mockCP.EXPECT().Run(ctx, repo, repoPath, commit2),
+			mockHelper.EXPECT().PushContextWithAuth(ctx, githubToken),
+			mockPRHelper.
+				EXPECT().
+				Create(ctx, branch2, downstreamMainBranch, upstreamURL, commit2, createDraftPRs).
+				Return(&github.PullRequest{HTMLURL: github.String("some-string")}, nil),
+			mockCP.
+				EXPECT().
+				Run(ctx, repo, repoPath, commit1).
+				Return(randomError),
+			mockIssueHelper.
+				EXPECT().
+				Create(ctx, &ErrMatcher{Err: randomError}, upstreamURL, commit1).
+				Return(&github.Issue{HTMLURL: github.String("some-string")}, nil),
+		)
+
+		assert.NoError(
 			t,
-			repo.Storer.SetReference(ref),
+			s.Run(ctx),
 		)
-	}
+	})
 
-	ghRepoName := gh.RepoName{
-		Owner: repoOwner,
-		Repo:  repoName,
-	}
+	t.Run("it should skip commits from ignored authors", func(t *testing.T) {
 
-	since := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
-	logger := logr.Discard()
+		ctrl := gomock.NewController(t)
 
-	upstreamConfig := config.Upstream{
-		Ref: upstreamMainBranch,
-		URL: upstreamURL,
-	}
+		const (
+			createDraftPRs       = true
+			downstreamMainBranch = "main"
+			dryRun               = false
+			githubToken          = "github-token"
+			repoOwner            = "owner"
+			repoPath             = "/repo/path"
+			repoName             = "repo"
+			upstreamMainBranch   = "us-main"
+			upstreamURL          = "some-upstream-url"
+			ignoredAuthor        = "ignored-author"
+		)
 
-	s := Sync{
-		CherryPicker: mockCP,
-		Differ:       mockDiffer,
-		DiffConfig: config.Diff{
-			CommitsSince: &since,
-		},
-		DryRun:      dryRun,
-		GitHelper:   mockHelper,
-		GitHubToken: githubToken,
-		IssueHelper: mockIssueHelper,
-		Repo:        repo,
-		RepoName:    &ghRepoName,
-		DownstreamConfig: config.Downstream{
-			CreateDraftPRs: createDraftPRs,
-			LocalRepoPath:  repoPath,
-			MainBranch:     downstreamMainBranch,
-			MaxOpenItems:   -1,
-		},
-		Logger:         logger,
-		PRHelper:       mockPRHelper,
-		UpstreamConfig: upstreamConfig,
-	}
+		mockCP := gitutils.NewMockCherryPicker(ctrl)
+		mockIssueHelper := gh.NewMockIssueHelper(ctrl)
+		mockPRHelper := gh.NewMockPRHelper(ctrl)
+		mockDiffer := gitutils.NewMockDiffer(ctrl)
+		mockHelper := gitutils.NewMockHelper(ctrl)
 
-	const (
-		sha1    = "e3229f3c533ed51070beff092e5c7694a8ee81f0"
-		sha2    = "9c08d42326af62aa0f8cea021c4d37971606148f"
-		branch2 = "gs-" + sha2
-	)
+		ctx := context.Background()
 
-	commit1 := &object.Commit{
-		Hash: plumbing.NewHash(sha1),
-		Committer: object.Signature{
-			When: time.Date(2022, 5, 1, 0, 0, 0, 0, time.UTC),
-		},
-	}
+		repo := test.NewRepo(t)
+		sha, _ := test.AddEmptyCommit(t, repo, "test commit")
 
-	commit2 := &object.Commit{
-		Hash: plumbing.NewHash(sha2),
-		Committer: object.Signature{
-			When: time.Date(2022, 4, 1, 0, 0, 0, 0, time.UTC),
-		},
-	}
+		for _, name := range []string{upstreamMainBranch, downstreamMainBranch} {
+			ref := plumbing.NewHashReference(
+				plumbing.NewBranchReferenceName(name),
+				sha,
+			)
 
-	randomError := errors.New("random error")
+			require.NoError(
+				t,
+				repo.Storer.SetReference(ref),
+			)
+		}
 
-	gomock.InOrder(
-		mockDiffer.
-			EXPECT().
-			GetMissingCommits(ctx, repo, &ghRepoName, &since, downstreamMainBranch, upstreamConfig).
-			Return([]*object.Commit{commit1, commit2}, nil),
-		mockIssueHelper.EXPECT().ListAllOpen(gomock.Any(), true),
-		mockCP.EXPECT().Run(ctx, repo, repoPath, commit2),
-		mockHelper.EXPECT().PushContextWithAuth(ctx, githubToken),
-		mockPRHelper.
-			EXPECT().
-			Create(ctx, branch2, downstreamMainBranch, upstreamURL, commit2, createDraftPRs).
-			Return(&github.PullRequest{HTMLURL: github.String("some-string")}, nil),
-		mockCP.
-			EXPECT().
-			Run(ctx, repo, repoPath, commit1).
-			Return(randomError),
-		mockIssueHelper.
-			EXPECT().
-			Create(ctx, &ErrMatcher{Err: randomError}, upstreamURL, commit1).
-			Return(&github.Issue{HTMLURL: github.String("some-string")}, nil),
-	)
+		ghRepoName := gh.RepoName{
+			Owner: repoOwner,
+			Repo:  repoName,
+		}
 
-	assert.NoError(
-		t,
-		s.Run(ctx),
-	)
+		since := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
+		logger := logr.Discard()
+
+		upstreamConfig := config.Upstream{
+			Ref: upstreamMainBranch,
+			URL: upstreamURL,
+		}
+
+		s := Sync{
+			CherryPicker: mockCP,
+			Differ:       mockDiffer,
+			DiffConfig: config.Diff{
+				CommitsSince: &since,
+			},
+			DryRun:      dryRun,
+			GitHelper:   mockHelper,
+			GitHubToken: githubToken,
+			IssueHelper: mockIssueHelper,
+			Repo:        repo,
+			RepoName:    &ghRepoName,
+			DownstreamConfig: config.Downstream{
+				CreateDraftPRs: createDraftPRs,
+				LocalRepoPath:  repoPath,
+				MainBranch:     downstreamMainBranch,
+				MaxOpenItems:   -1,
+				IgnoreAuthors:  []string{ignoredAuthor},
+			},
+			Logger:         logger,
+			PRHelper:       mockPRHelper,
+			UpstreamConfig: upstreamConfig,
+		}
+
+		commits := []*object.Commit{
+			{
+				Hash: plumbing.NewHash(sha.String()),
+				Author: object.Signature{
+					Name: ignoredAuthor,
+				},
+			},
+		}
+
+		gomock.InOrder(
+			mockDiffer.
+				EXPECT().
+				GetMissingCommits(ctx, repo, &ghRepoName, &since, downstreamMainBranch, upstreamConfig).
+				Return(commits, nil),
+			mockIssueHelper.EXPECT().ListAllOpen(gomock.Any(), true),
+		)
+
+		assert.NoError(
+			t,
+			s.Run(ctx),
+		)
+	})
 }
 
 type ErrMatcher struct {


### PR DESCRIPTION
Allow black-listing authors from the `sync` subcommand.

This will allow us to set the config to skip certain commits such as
`dependabot` commits.

We have `dependabot` set m/s as well so no need to duplicate the
PRs/Issues.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>