### PR TITLE
Getting the Github author login by searching a commit.

### DIFF
--- a/internal/github/mock_user.go
+++ b/internal/github/mock_user.go
@@ -8,7 +8,6 @@ import (
 	context "context"
 	reflect "reflect"
 
-	object "github.com/go-git/go-git/v5/plumbing/object"
 	gomock "github.com/golang/mock/gomock"
 	github "github.com/google/go-github/v47/github"
 )
@@ -36,17 +35,17 @@ func (m *MockUserHelper) EXPECT() *MockUserHelperMockRecorder {
 	return m.recorder
 }
 
-// GetUser mocks base method.
-func (m *MockUserHelper) GetUser(ctx context.Context, commit *object.Commit) (*github.User, error) {
+// GetCommitAuthor mocks base method.
+func (m *MockUserHelper) GetCommitAuthor(ctx context.Context, sha string) (*github.User, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUser", ctx, commit)
+	ret := m.ctrl.Call(m, "GetCommitAuthor", ctx, sha)
 	ret0, _ := ret[0].(*github.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetUser indicates an expected call of GetUser.
-func (mr *MockUserHelperMockRecorder) GetUser(ctx, commit interface{}) *gomock.Call {
+// GetCommitAuthor indicates an expected call of GetCommitAuthor.
+func (mr *MockUserHelperMockRecorder) GetCommitAuthor(ctx, sha interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockUserHelper)(nil).GetUser), ctx, commit)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCommitAuthor", reflect.TypeOf((*MockUserHelper)(nil).GetCommitAuthor), ctx, sha)
 }

--- a/internal/gitstream/assign.go
+++ b/internal/gitstream/assign.go
@@ -97,11 +97,6 @@ func (a *Assign) assignIssues(ctx context.Context) error {
 
 		for _, s := range shas {
 
-			upstreamCommit, err := a.Repo.CommitObject(s)
-			if err != nil {
-				return fmt.Errorf("could not find upstream commit %s: %v", s, err)
-			}
-
 			if a.DryRun {
 				logger.Info("Dry run: skipping issue update")
 				return nil
@@ -113,7 +108,7 @@ func (a *Assign) assignIssues(ctx context.Context) error {
 				assignee string
 				intErr   error
 			)
-			if user, err := a.UserHelper.GetUser(ctx, upstreamCommit); err != nil {
+			if user, err := a.UserHelper.GetCommitAuthor(ctx, s.String()); err != nil {
 				if !errors.Is(err, gh.ErrUnexpectedReply) {
 					logger.Info("WARNING: failed to get a response from Github, skipping commit",
 						"issue", *issue.Number, "error", gh.ErrUnexpectedReply)

--- a/internal/gitstream/assign_test.go
+++ b/internal/gitstream/assign_test.go
@@ -537,19 +537,19 @@ reviewers:
 			},
 		}
 
-		sha, commit := test.AddEmptyCommit(t, repo, "empty")
+		sha, _ := test.AddEmptyCommit(t, repo, "empty")
 
 		gomock.InOrder(
 			mockIssueHelper.EXPECT().ListAllOpen(ctx, true).Return(issues, nil),
 			mockFinder.EXPECT().FindSHAs(body).Return([]plumbing.Hash{sha}, nil),
-			mockUserHelper.EXPECT().GetUser(ctx, commit).Return(nil, errors.New("some API error")),
+			mockUserHelper.EXPECT().GetCommitAuthor(ctx, sha.String()).Return(nil, errors.New("some API error")),
 		)
 
 		err := a.assignIssues(ctx)
 		assert.NoError(t, err)
 	})
 
-	t.Run("failed to get user, not found", func(t *testing.T) {
+	t.Run("failed to get user, commit not found", func(t *testing.T) {
 
 		var (
 			ctx = context.Background()
@@ -618,12 +618,12 @@ reviewers:
 			},
 		}
 
-		sha, commit := test.AddEmptyCommit(t, repo, "empty")
+		sha, _ := test.AddEmptyCommit(t, repo, "empty")
 
 		gomock.InOrder(
 			mockIssueHelper.EXPECT().ListAllOpen(ctx, true).Return(issues, nil),
 			mockFinder.EXPECT().FindSHAs(body).Return([]plumbing.Hash{sha}, nil),
-			mockUserHelper.EXPECT().GetUser(ctx, commit).Return(nil, gh.ErrUnexpectedReply),
+			mockUserHelper.EXPECT().GetCommitAuthor(ctx, sha.String()).Return(nil, gh.ErrUnexpectedReply),
 			mockIssueHelper.EXPECT().Assign(ctx, issues[0], gomock.Any()).Return(nil),
 		)
 
@@ -704,12 +704,12 @@ reviewers:
 			Login: &approver,
 		}
 
-		sha, commit := test.AddEmptyCommit(t, repo, "empty")
+		sha, _ := test.AddEmptyCommit(t, repo, "empty")
 
 		gomock.InOrder(
 			mockIssueHelper.EXPECT().ListAllOpen(ctx, true).Return(issues, nil),
 			mockFinder.EXPECT().FindSHAs(body).Return([]plumbing.Hash{sha}, nil),
-			mockUserHelper.EXPECT().GetUser(ctx, commit).Return(user, nil),
+			mockUserHelper.EXPECT().GetCommitAuthor(ctx, sha.String()).Return(user, nil),
 			mockIssueHelper.EXPECT().Assign(ctx, issues[0], approver).Return(nil),
 		)
 
@@ -791,12 +791,12 @@ reviewers:
 			Login: &nonApprover,
 		}
 
-		sha, commit := test.AddEmptyCommit(t, repo, "empty")
+		sha, _ := test.AddEmptyCommit(t, repo, "empty")
 
 		gomock.InOrder(
 			mockIssueHelper.EXPECT().ListAllOpen(ctx, true).Return(issues, nil),
 			mockFinder.EXPECT().FindSHAs(body).Return([]plumbing.Hash{sha}, nil),
-			mockUserHelper.EXPECT().GetUser(ctx, commit).Return(user, nil),
+			mockUserHelper.EXPECT().GetCommitAuthor(ctx, sha.String()).Return(user, nil),
 			mockIssueHelper.EXPECT().Assign(ctx, issues[0], approver).Return(nil),
 		)
 
@@ -878,12 +878,12 @@ reviewers:
 			Login: &userLogin,
 		}
 
-		sha, commit := test.AddEmptyCommit(t, repo, "empty")
+		sha, _ := test.AddEmptyCommit(t, repo, "empty")
 
 		gomock.InOrder(
 			mockIssueHelper.EXPECT().ListAllOpen(ctx, true).Return(issues, nil),
 			mockFinder.EXPECT().FindSHAs(body).Return([]plumbing.Hash{sha}, nil),
-			mockUserHelper.EXPECT().GetUser(ctx, commit).Return(user, nil),
+			mockUserHelper.EXPECT().GetCommitAuthor(ctx, sha.String()).Return(user, nil),
 			mockIssueHelper.EXPECT().Assign(ctx, issues[0], userLogin).Return(errors.New("error")),
 		)
 
@@ -966,12 +966,12 @@ reviewers:
 			Login: &userLogin,
 		}
 
-		sha, commit := test.AddEmptyCommit(t, repo, "empty")
+		sha, _ := test.AddEmptyCommit(t, repo, "empty")
 
 		gomock.InOrder(
 			mockIssueHelper.EXPECT().ListAllOpen(ctx, true).Return(issues, nil),
 			mockFinder.EXPECT().FindSHAs(body).Return([]plumbing.Hash{sha}, nil),
-			mockUserHelper.EXPECT().GetUser(ctx, commit).Return(user, nil),
+			mockUserHelper.EXPECT().GetCommitAuthor(ctx, sha.String()).Return(user, nil),
 			mockIssueHelper.EXPECT().Assign(ctx, issues[0], userLogin).Return(nil),
 		)
 


### PR DESCRIPTION
The current implementation searches the user based on his `git` email, which means that if a user as a different email configured in his local `.git/config` file and in his primary email on Github we will fail to find him based on his email.

This commit is about to solve this issue but searching for the commit that was introduced in a PR and extracting the commit author from there.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>

---

Fixes https://github.com/qbarrand/gitstream/issues/44