### PR TITLE
Fixing the search query for getting commits.

### DIFF
--- a/internal/github/user.go
+++ b/internal/github/user.go
@@ -31,7 +31,7 @@ var ErrUnexpectedReply = errors.New("the number of found commits isn't exactly 1
 
 func (uh *UserHelperImpl) GetCommitAuthor(ctx context.Context, sha string) (*github.User, error) {
 
-	q := fmt.Sprintf("hash:%s repo:%s/%s", sha, uh.repoName.Owner, uh.repoName.Repo)
+	q := fmt.Sprintf("hash:%s+repo:%s/%s", sha, uh.repoName.Owner, uh.repoName.Repo)
 	commitSearchRes, _, err := uh.gc.Search.Commits(ctx, q, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get commit %s: %v", sha, err)

--- a/internal/github/user_test.go
+++ b/internal/github/user_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUserHelperImpl_GetUser(t *testing.T) {
+func TestUserHelperImpl_GetCommitAuthor(t *testing.T) {
 
 	const (
 		owner     = "owner"
@@ -23,7 +23,7 @@ func TestUserHelperImpl_GetUser(t *testing.T) {
 
 	var (
 		authorLogin = "suser"
-		q           = fmt.Sprintf("hash:%s repo:%s/%s", commitSha, owner, repo)
+		q           = fmt.Sprintf("hash:%s+repo:%s/%s", commitSha, owner, repo)
 	)
 
 	ctx := context.Background()


### PR DESCRIPTION
When using multiple search filters as we do the separator should be `+` instead of ` ` otherwise we will get an error and a random approver will be assigned.

---

Fixes https://github.com/qbarrand/gitstream/issues/56